### PR TITLE
Fixes automatic Result choice for certain dice formats

### DIFF
--- a/dice_test.go
+++ b/dice_test.go
@@ -1,0 +1,38 @@
+package dice_test
+
+import (
+	"testing"
+
+	. "github.com/justinian/dice"
+)
+
+func TestRoll(t *testing.T) {
+	roll := "3d8v3"
+	res, _, _ := Roll(roll)
+	if _, ok := res.(VsResult); !ok {
+		t.Fatalf("%s is not a VsResult", roll)
+	}
+
+	roll = "3d8+2test"
+	_, _, err := Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "3b4bl"
+	_, reason, err := Roll(roll)
+	if reason == "4bl" {
+		t.Fatalf("malformed dice format read as reason, %s", roll)
+	}
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	}
+
+	roll = "9d9rv5"
+	res, _, _ = Roll(roll)
+	if _, ok := res.(VsResult); !ok {
+		t.Fatalf("%s is not a VsResult", roll)
+	}
+}

--- a/eote.go
+++ b/eote.go
@@ -73,7 +73,7 @@ var eoteDice = map[string][]EoteResult{
 
 type EoteRoller struct{}
 
-var eotePattern = regexp.MustCompile(`([0-9]+(?:r|b|blk|p|g|y|w)\s*)+`)
+var eotePattern = regexp.MustCompile(`([0-9]+(?:r|b|blk|p|g|y|w)\s*)+($|\s)`)
 var diePattern = regexp.MustCompile(`([0-9]+)(r|b|blk|p|g|y|w)`)
 
 func (EoteRoller) Pattern() *regexp.Regexp { return eotePattern }

--- a/std.go
+++ b/std.go
@@ -9,7 +9,7 @@ import (
 
 type StdRoller struct{}
 
-var stdPattern = regexp.MustCompile(`([0-9]+)d([0-9]+)([+-][0-9]+)?`)
+var stdPattern = regexp.MustCompile(`([0-9]+)d([0-9]+)([+-][0-9]+)?($|\s)`)
 
 func (StdRoller) Pattern() *regexp.Regexp { return stdPattern }
 

--- a/versus.go
+++ b/versus.go
@@ -10,7 +10,7 @@ import (
 
 type VsRoller struct{}
 
-var vsPattern = regexp.MustCompile(`([0-9]+)d([0-9]+)(e|rr)?v([0-9]+)($|\s)`)
+var vsPattern = regexp.MustCompile(`([0-9]+)d([0-9]+)(e|r)?v([0-9]+)($|\s)`)
 
 func (VsRoller) Pattern() *regexp.Regexp { return vsPattern }
 
@@ -44,7 +44,7 @@ func (VsRoller) Roll(matches []string) (RollResult, error) {
 	}
 
 	explode := matches[3] == "e"
-	reroll := matches[3] == "rr"
+	reroll := matches[3] == "r"
 
 	target, err := strconv.ParseInt(matches[4], 10, 0)
 	if err != nil {

--- a/versus.go
+++ b/versus.go
@@ -10,7 +10,7 @@ import (
 
 type VsRoller struct{}
 
-var vsPattern = regexp.MustCompile(`([0-9]+)d([0-9]+)(e|r)?v([0-9]+)`)
+var vsPattern = regexp.MustCompile(`([0-9]+)d([0-9]+)(e|rr)?v([0-9]+)($|\s)`)
 
 func (VsRoller) Pattern() *regexp.Regexp { return vsPattern }
 
@@ -44,7 +44,7 @@ func (VsRoller) Roll(matches []string) (RollResult, error) {
 	}
 
 	explode := matches[3] == "e"
-	reroll := matches[3] == "r"
+	reroll := matches[3] == "rr"
 
 	target, err := strconv.ParseInt(matches[4], 10, 0)
 	if err != nil {


### PR DESCRIPTION
See the test for details, but the motivating string for these changes was:

"3d8v3", which dice.Roll currently interprets as a StdResult, not a VsResult, the 'v3' listed as the reason for the StdResult.

This does enforce that the 'reason' must be seperated from the dice format by a space.
