### PR TITLE
Add support for fudge dices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a simple library for rolling RPG-style dice. The following formats are supported:
 
 * Standard: `xdy[[k|d][h|l]z][+/-c]` - rolls and sums x y-sided dice, keeping or dropping the lowest or highest z dice and optionally adding or subtracting c. Example: 4d6kh3+4
+* Fudge: `xdf[+/-c]` - rolls and sums x fudge dice (Dice that returns numbers between -1 and 1), and optionally adding or subtracting c. Example: 4df+4
 * Versus: `xdy[e|r]vt` - rolls x y-sided dice, counting the number that roll t or greater.
 * EotE: `xc [xc ...]` - rolls x dice of color c (b, blk, g, p, r, w, y) and returns the aggregate result.
 

--- a/fudge.go
+++ b/fudge.go
@@ -49,15 +49,11 @@ func (FudgeRoller) Roll(matches []string) (RollResult, error) {
 	}
 
 	for i := 0; i < len(result.Rolls); i++ {
-		roll := rand.Intn(3) - 1
-		result.Rolls[i] = roll
+		result.Rolls[i] = rand.Intn(3) - 1
+		result.Total += result.Rolls[i]
 	}
 
 	sort.Ints(result.Rolls)
-
-	for i := 0; i < len(result.Rolls); i++ {
-		result.Total += result.Rolls[i]
-	}
 
 	return result, nil
 }

--- a/fudge.go
+++ b/fudge.go
@@ -1,0 +1,67 @@
+package dice
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+type FudgeRoller struct{}
+
+var fudgePattern = regexp.MustCompile(`([0-9]+)df?([+-][0-9]+)?($|\s)`)
+
+func (FudgeRoller) Pattern() *regexp.Regexp { return fudgePattern }
+
+type FudgeResult struct {
+	basicRollResult
+	Rolls []int
+	Total int
+}
+
+func (r FudgeResult) String() string {
+	return fmt.Sprintf("%d %v", r.Total, r.Rolls)
+}
+
+func (r FudgeResult) Int() int {
+	return r.Total
+}
+
+func (FudgeRoller) Roll(matches []string) (RollResult, error) {
+	dice, err := strconv.ParseInt(matches[1], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	result := FudgeResult{
+		basicRollResult: basicRollResult{matches[0]},
+		Rolls:           make([]int, dice),
+		Total:           0,
+	}
+
+	if matches[2] != "" {
+		bonus, err := strconv.ParseInt(matches[2], 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		result.Total += int(bonus)
+	}
+
+	for i := 0; i < len(result.Rolls); i++ {
+		roll := rand.Intn(3) - 1
+		result.Rolls[i] = roll
+	}
+
+	sort.Ints(result.Rolls)
+
+	for i := 0; i < len(result.Rolls); i++ {
+		result.Total += result.Rolls[i]
+	}
+
+	return result, nil
+}
+
+func init() {
+	addRollHandler(FudgeRoller{})
+}

--- a/fudge_test.go
+++ b/fudge_test.go
@@ -1,0 +1,84 @@
+package dice_test
+
+import (
+	"testing"
+
+	. "github.com/justinian/dice"
+	. "gopkg.in/check.v1"
+)
+
+/* =============================================================================
+ * Fudge dice test suite
+ */
+
+func TestFudge(t *testing.T) { TestingT(t) }
+
+type fudgeSuite struct {
+}
+
+/*
+func (s *DiceSuite) SetUpSuite(c *C) {
+}
+
+func (s *DiceSuite) SetUpTest(c *C) {
+}
+*/
+
+var _ = Suite(&fudgeSuite{})
+
+/* =============================================================================
+ * Std dice test cases
+ */
+
+func (s *fudgeSuite) TestBounds(c *C) {
+	var roller FudgeRoller
+
+	r, err := roller.Roll([]string{"100df", "100", "", ""})
+	res := r.(FudgeResult)
+
+	c.Assert(err, IsNil)
+
+	for _, v := range res.Rolls {
+		if v < -1 || v > +1 {
+			c.Errorf("Rolled out of bounds on a dF: %d", v)
+		}
+	}
+}
+
+func (s *fudgeSuite) TestCount(c *C) {
+	var roller FudgeRoller
+
+	r, err := roller.Roll([]string{"100df", "100", "", ""})
+	res := r.(FudgeResult)
+
+	c.Assert(err, IsNil)
+	c.Assert(res.Rolls, HasLen, 100)
+}
+
+func (s *fudgeSuite) TestAdd(c *C) {
+	var roller FudgeRoller
+
+	r, err := roller.Roll([]string{"1df+13", "1", "+13"})
+	res := r.(FudgeResult)
+
+	if res.Total < 12 || res.Total > 14 {
+		c.Errorf("Added roll out of bounds on a dF: %d", res.Total)
+	}
+
+	c.Assert(err, IsNil)
+	c.Assert(res.Rolls, HasLen, 1)
+}
+
+func (s *fudgeSuite) TestSubtract(c *C) {
+	var roller FudgeRoller
+
+	r, err := roller.Roll([]string{"1df+13", "1", "-13"})
+	res := r.(FudgeResult)
+
+	if res.Total < -14 || res.Total > -12 {
+		c.Errorf("Added roll out of bounds on a dF: %d", res.Total)
+	}
+
+	c.Assert(err, IsNil)
+	c.Assert(res.Rolls, HasLen, 1)
+}

--- a/fudge_test.go
+++ b/fudge_test.go
@@ -18,7 +18,7 @@ type fudgeSuite struct{}
 var _ = Suite(&fudgeSuite{})
 
 /* =============================================================================
- * Std dice test cases
+ * Fudge dice test cases
  */
 
 func (s *fudgeSuite) TestBounds(c *C) {

--- a/fudge_test.go
+++ b/fudge_test.go
@@ -15,14 +15,6 @@ func TestFudge(t *testing.T) { TestingT(t) }
 
 type fudgeSuite struct{}
 
-/*
-func (s *DiceSuite) SetUpSuite(c *C) {
-}
-
-func (s *DiceSuite) SetUpTest(c *C) {
-}
-*/
-
 var _ = Suite(&fudgeSuite{})
 
 /* =============================================================================

--- a/fudge_test.go
+++ b/fudge_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestFudge(t *testing.T) { TestingT(t) }
 
-type fudgeSuite struct {
-}
+type fudgeSuite struct{}
 
 /*
 func (s *DiceSuite) SetUpSuite(c *C) {


### PR DESCRIPTION
This PR adds support for [Fudge dice](https://en.wikipedia.org/wiki/Fudge_(role-playing_game_system)#Fudge_dice).

It can be rolled using `roll 4df`. Only subtract and add operations are supported.