### PR TITLE
Fix a crash on a zero sided dice

### DIFF
--- a/dice_test.go
+++ b/dice_test.go
@@ -21,6 +21,22 @@ func TestRoll(t *testing.T) {
 		t.Fatalf("err not detected in %s", roll)
 	}
 
+	roll = "4d0"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "4d0v5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
 	roll = "3b4bl"
 	_, reason, err := Roll(roll)
 	if reason == "4bl" {

--- a/std.go
+++ b/std.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"regexp"
@@ -38,6 +39,9 @@ func (StdRoller) Roll(matches []string) (RollResult, error) {
 	sides, err := strconv.ParseInt(matches[2], 10, 0)
 	if err != nil {
 		return nil, err
+	}
+	if sides <= 0 {
+		return nil, errors.New("Sides must be 1 or more")
 	}
 
 	keep := ""


### PR DESCRIPTION
Throwing a zero sided *standard* dice (`4d0`) caused a crash because `rand.Intn()` requires the number to be greater than zero. This is fixed by adding a check for the number of sides.

Tests for both the *standard* and *versus* formats are included.
