### PR TITLE
Fix crashes when keeping or dropping more dice than rolled

### DIFF
--- a/dice_test.go
+++ b/dice_test.go
@@ -51,6 +51,39 @@ func TestRoll(t *testing.T) {
 	if _, ok := res.(VsResult); !ok {
 		t.Fatalf("%s is not a VsResult", roll)
 	}
+
+	// Trying to keep or drop too many dice
+	roll = "2d6k5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "2d6kl5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "2d6dh5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "2d6dl5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
 }
 
 func TestText(t *testing.T) {

--- a/std.go
+++ b/std.go
@@ -82,19 +82,33 @@ func (StdRoller) Roll(matches []string) (RollResult, error) {
 	case "k":
 		fallthrough
 	case "kh":
-		result.Dropped = result.Rolls[:size-num]
-		result.Rolls = result.Rolls[size-num:]
+		slice := size - num
+		if slice < 0 {
+			return nil, errors.New("Can't keep more dice than rolled")
+		}
+		result.Dropped = result.Rolls[:slice]
+		result.Rolls = result.Rolls[slice:]
 	case "d":
 		fallthrough
 	case "dl":
+		if num > size {
+			return nil, errors.New("Can't drop more dice than rolled")
+		}
 		result.Dropped = result.Rolls[:num]
 		result.Rolls = result.Rolls[num:]
 	case "kl":
+		if num > size {
+			return nil, errors.New("Can't keep more dice than rolled")
+		}
 		result.Dropped = result.Rolls[num:]
 		result.Rolls = result.Rolls[:num]
 	case "dh":
-		result.Dropped = result.Rolls[size-num:]
-		result.Rolls = result.Rolls[:size-num]
+		slice := size - num
+		if slice < 0 {
+			return nil, errors.New("Can't drop more dice than rolled")
+		}
+		result.Dropped = result.Rolls[slice:]
+		result.Rolls = result.Rolls[:slice]
 	}
 
 	for i := 0; i < len(result.Rolls); i++ {


### PR DESCRIPTION
Fixes #12, the issue was caused by trying to keep or drop more dice than how many dice were rolled.